### PR TITLE
Add Codex to known implementations

### DIFF
--- a/v1.0.md
+++ b/v1.0.md
@@ -79,5 +79,4 @@ The Link **MUST** contain the following attributes:
 
 ## Credit
 
-This document has been slightly modified to accomodate the form and style.
-The original 1.0 specification has been created by Tom for Ubooquity, and can be found at https://vaemendis.net/opds-pse/. 
+This document has been slightly modified to accommodate the form and style.

--- a/v1.0.md
+++ b/v1.0.md
@@ -80,3 +80,4 @@ The Link **MUST** contain the following attributes:
 ## Credit
 
 This document has been slightly modified to accommodate the form and style.
+The original 1.0 specification has been created by Tom for Ubooquity, and can be found at https://vaemendis.net/opds-pse/.

--- a/v1.0.md
+++ b/v1.0.md
@@ -69,6 +69,7 @@ The Link **MUST** contain the following attributes:
 - [Ubooquity](http://vaemendis.net/ubooquity/)
 - [Komga](https://komga.org/)
 - [Kavita](https://www.kavitareader.com/)
+- [Codex](https://github.com/ajslater/codex/)
 
 ### Client
 

--- a/v1.0.md
+++ b/v1.0.md
@@ -80,4 +80,4 @@ The Link **MUST** contain the following attributes:
 ## Credit
 
 This document has been slightly modified to accommodate the form and style.
-The original 1.0 specification has been created by Tom for Ubooquity, and can be found at https://vaemendis.net/opds-pse/.
+The original 1.0 specification has been created by Tom for Ubooquity, and can be found at https://vaemendis.net/opds-pse/. 

--- a/v1.1.md
+++ b/v1.1.md
@@ -71,6 +71,7 @@ The Link **MAY** contain the following attributes:
 ### Server
 
 - [Komga](https://komga.org/)
+- [Codex](https://github.com/ajslater/codex/)
 
 ### Client
 


### PR DESCRIPTION
Codex has implemented opds-pse v1.1 since v0.13.0, about a month ago.

(this pr also fixes a small spelling mistake)