### PR TITLE
[Proposal] - New lastReadDate attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.2
 
 ### Features
-- add new attribute `lastReadUpdate` on the acquisition link
+- add new attribute `lastReadDate` on the acquisition link
 
 ## 1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.2
+
+### Features
+- add new attribute `lastReadUpdate` on the acquisition link
+
 ## 1.1
 
 ### Features

--- a/v1.2.md
+++ b/v1.2.md
@@ -45,7 +45,7 @@ Additional link in an entry to allow page by page access to the document:
       href="/opds-comics/stream/1217?page={pageNumber}&width={maxWidth}"
       pse:count="35"
       pse:lastRead="10"
-      pse:lastReadUpdate="2010-01-10T10:01:11Z"
+      pse:lastReadDate="2010-01-10T10:01:11Z"
 />
 ```
 
@@ -61,7 +61,7 @@ The Link **MUST** contain the following attributes:
 
 The Link **MAY** contain the following attributes:
 - `lastRead` **MUST** provide the last page read for this document. The numbering starts at 1.
-- `lastReadUpdate` **MAY** provide the date of when the `lastRead` attribute was last updated. Attribute **MUST** conform [Atom's Date construct](https://www.rfc-editor.org/rfc/rfc4287#section-3.3).
+- `lastReadDate` **MAY** provide the date of when the `lastRead` attribute was last updated. Attribute **MUST** conform [Atom's Date construct](https://www.rfc-editor.org/rfc/rfc4287#section-3.3).
 
 ### Notes
 

--- a/v1.2.md
+++ b/v1.2.md
@@ -1,0 +1,81 @@
+# OPDS Page Streaming Extension 1.2
+
+Published on March 05th 2023
+
+## License
+
+This document is licensed under [Creative Commons Attribution-Share Alike](http://creativecommons.org/licenses/by-sa/3.0/).
+
+## Introduction
+
+The OPDS Page Streaming Extension (OPDS-PSE) is an **_unofficial_** extension of the [Open Distribution Publication System](https://specs.opds.io/opds-1.2). Its goal is to enrich the OPDS feed with information allowing the client to request a specific page of a document without having to download it completely.
+This extension was designed primarily for comic books, to allow reading them on connected devices without having to wait for the book to be completely downloaded.
+
+OPDS-PSE adds new attributes and conventions but does not break compatibility. OPDS-PSE feeds are still valid OPDS feeds.
+
+## Notational Conventions
+
+The keywords **"MUST"**, **"MUST NOT"**, **"SHOULD"**, **"MAY"**, and **"OPTIONAL"** in this document are to be interpreted as described in [[RFC2119]](https://www.ietf.org/rfc/rfc2119.txt).
+
+## OPDS-PSE acquisition Link
+
+The OPDS-PSE extension simply consists in an additional type of [Acquisition Link](http://opds-spec.org/specs/opds-catalog-1-1-20110627/#Acquiring_Publications) in an [OPDS entry](http://opds-spec.org/specs/opds-catalog-1-1-20110627/#OPDS_Catalog_Entry_Documents).
+This link is to be used by clients to request pages of a document, one page at a time.
+
+An OPDS-PSE feed MUST declare the OPDS-PSE namespace: `http://vaemendis.net/opds-pse/ns`
+
+### Example
+
+Namespace declaration in the feed element (in our example, we use the prefix `pse`):
+
+```xml
+<feed xmlns="http://www.w3.org/2005/Atom"
+      xmlns:dcterms="http://purl.org/dc/terms/"
+      xmlns:pse="http://vaemendis.net/opds-pse/ns"
+      xmlns:opds="http://opds-spec.org/2010/catalog"
+      xml:lang="en"
+      xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/">
+```
+
+Additional link in an entry to allow page by page access to the document:
+
+```xml
+<link rel="http://vaemendis.net/opds-pse/stream"
+      type="image/jpeg"
+      href="/opds-comics/stream/1217?page={pageNumber}&width={maxWidth}"
+      pse:count="35"
+      pse:lastRead="10"
+      pse:lastReadUpdate="2010-01-10T10:01:11Z"
+/>
+```
+
+### Specifications
+
+The Link **MUST** contain the following attributes:
+- `rel` **MUST** have the value `http://vaemendis.net/opds-pse/stream` that indicates that this link is a OPDS-PSE page streaming link
+- `type` **MUST** indicate the type of image returned by the server (value **MUST** be one of the following : `image/jpeg`, `image/gif` or `image/png`)
+- `count` **MUST** provide the number of pages of the document
+- `href` **MUST** provide the URL that the client has to use to get individual pages of the document.
+  This URL **MUST** contain the string `{pageNumber}`, which the client **MUST** replace with the number of the desired page.
+  This URL **MAY** contain the string `{maxWidth}` that the client **MUST** replace (if it exists) by the desired maximum width of the returned page.
+
+The Link **MAY** contain the following attributes:
+- `lastRead` **MUST** provide the last page read for this document. The numbering starts at 1.
+- `lastReadUpdate` **MAY** provide the date of when the `lastRead` attribute was last updated. Attribute **MUST** conform [Atom's Date construct](https://www.rfc-editor.org/rfc/rfc4287#section-3.3).
+
+### Notes
+
+- pages are numbered from `0` to `N-1` (`N` being the total number of pages).
+- double pages (one image containing two pages) **MUST** be treated as a single page. If a split is to be done, it is the responsibility of the client. The server **MUST NOT** split images.
+
+## Known implementations of OPDS-PSE 1.2
+
+### Server
+
+TBD
+
+### Client
+
+TBD
+
+


### PR DESCRIPTION
## Context 

Clients like Panels have support for OPDS-PSE 1.1 but also have their own methods for tracking the reading progress of a comic. 
The `lastRead` is an excellent way for clients to open the reader on the last page read on the OPDS-compatible server. But the information does not suffice when the client needs to keep the different reading progresses in sync. 

At Panels, we are adding support for syncing reading progress with Komga (and soon Kavita) using their API, but our Remote Library UI only uses the OPDS feed. To keep the local reading and the server reading progress in sync, we would have to couple our OPDS client with the different API client implementations, which is not ideal. And also, make one request per comic to get the latest read date. 

## Proposal

Suppose OPDS-PSE provides a new `lastReadDate` attribute with the date and time the reading session was updated on the server. Clients like Panels could compare that date with the local reading session one to know whether the remote `lastRead` is newer than the one stored locally. 

## Notes 

I defined the `lastReadUpdate` as optional to not introduce breaking changes. But I'd love your feedback. Given that `lastRead` is already optional, maybe it's ok to tie both attributes and require `lastReadDate` if `lastRead` is provided. 
But I don't have much context about the server side and don't know whether this is reasonable. 