### PR TITLE
Add LANraragi as an OPDS 1.2 implementation

### DIFF
--- a/v1.2.md
+++ b/v1.2.md
@@ -75,6 +75,7 @@ The Link **MAY** contain the following attributes:
 - [Komga](https://komga.org/)
 - [Kavita](https://www.kavitareader.com/)
 - [Codex](https://github.com/ajslater/codex/)
+- [LANraragi](https://github.com/Difegue/LANraragi)
 
 ### Client
 


### PR DESCRIPTION
👋 1.2 support was available in my nightlies for a while but I finally made a [release with it](https://github.com/Difegue/LANraragi/releases/tag/v.0.9.0), so I get to edit this doc now 😛